### PR TITLE
Add Nosfet Xeno and fix BLE multi-connection on ESP32-C6

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,13 +25,14 @@ Always run `esphome config <file>.yaml` after editing any YAML to catch validati
 
 ## Project Structure
 
-Three entry-point configs, each a different device combination:
+Entry-point configs, each a different device combination:
 
 | File | Devices |
 |---|---|
-| `esphome-lynx-charger.yaml` | Veteran Lynx + Fast charger |
-| `esphome-nosfet-charger.yaml` | Nosfet Aero + Fast charger |
-| `esphome-lynx-nosfet-charger.yaml` | Veteran Lynx + Nosfet Aero + Fast charger |
+| `esphome-euc-lynx-charger.yaml` | Veteran Lynx + Fast charger |
+| `esphome-euc-nosfet-charger.yaml` | Nosfet Aero + Fast charger |
+| `esphome-euc-lynx-nosfet-charger.yaml` | Veteran Lynx + Nosfet Aero + Nosfet Xeno + Fast charger |
+| `esphome-euc-lynx-nosfet-charger-c6.yaml` | same, for XIAO ESP32C6 board |
 
 Each config composes reusable packages via `!include`:
 - `package-veteran-device.yaml` — one Veteran/NOSFET wheel (parameterised via vars)
@@ -75,12 +76,38 @@ Extended payload sub-types (byte 46): `0x00/0x04` Live (controller temp, BMS cur
 
 `package-charger-device.yaml` vars: `charger_id`, `charger_mac`, `charger_device_id`.
 
+`euc_charge_stop_offset` is per-firmware and must be derived empirically. The component computes
+`charging_stop_voltage = read_u16_be(packet) + offset` and publishes it as `/10`. To find it: flash with any
+offset, read the published `Max charging voltage`, recover the raw value as `published * 10 - offset`, then set
+`offset = actual_volts * 10 - raw`.
+
+## ESP32-C6 BLE gotcha
+
+On the C6 board, `esp32_ble` needs an sdkconfig override or only ONE BLE connection will ever establish:
+
+```yaml
+sdkconfig_options:
+  CONFIG_BT_BLE_50_FEATURES_SUPPORTED: n
+  CONFIG_BT_LE_MAX_CONNECTIONS: "4"
+```
+
+- **BLE 4.2 vs 5.0** — ESPHome forces `CONFIG_BT_BLE_42_FEATURES_SUPPORTED=y`, while on C6 (`SOC_BLE_50_SUPPORTED`)
+  `CONFIG_BT_BLE_50_FEATURES_SUPPORTED` defaults to `y`. IDF's Kconfig states outright that
+  "BLE 4.2 and BLE 5.0 cannot be used simultaneously". With both on, Bluedroid issues LE Extended Create
+  Connection (HCI `0x2043`), the controller rejects it as `Cmd Disallowed`, and every client after the first
+  fails with `status=133`.
+- **Connection slots** — ESPHome maps `max_connections` onto `CONFIG_BTDM_CTRL_BLE_MAX_CONN`, which is the
+  *classic ESP32* controller option. C6 uses `CONFIG_BT_LE_MAX_CONNECTIONS`, left at its default 3.
+
+Neither applies to the plain `esp32dev` configs: classic ESP32 has no BLE 5.0 at all, and its controller option
+is the one ESPHome already sets.
+
 ## Secrets
 
 ```yaml
 wifi_ssid / wifi_password
 ha_encryption_key
-euc_veteran_mac / euc_nosfet_mac
+euc_veteran_mac / euc_nosfet_mac / euc_xeno_mac
 fast_charger_mac
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Возможности
 
-- Подключение до двух моноколёс одновременно (например, Veteran Lynx + NOSFET Aero)
+- Подключение нескольких моноколёс одновременно (например, Veteran Lynx + NOSFET Aero + NOSFET Xeno)
 - Мониторинг зарядного устройства Fast charger в реальном времени
 - Телеметрия: скорость, напряжение, заряд, температуры, пробег, BMS
 - Управление: фара, максимальное напряжение зарядки
@@ -30,14 +30,33 @@ cd esphome-euc
 
 Нужен реальный MAC вида `XX:XX:XX:XX:XX:XX`. Варианты:
 
-**macOS — системный лог (без доп. инструментов)**
+**macOS — в два шага**
+
+CoreBluetooth намеренно скрывает MAC: приложения (LightBlue, nRF Connect для iOS/macOS) видят только UUID, локальный для конкретного Mac. В унифицированном логе адреса и имена тоже редактируются как `<private>` — рецепт `log stream | grep adv-addr` на macOS 26 уже ничего не даёт.
+
+Рабочий путь — сопоставить имя с MAC через CoreBluetooth-UUID устройства.
+
+1. Найти UUID по имени:
 ```bash
-sudo log stream --predicate 'subsystem == "com.apple.bluetooth"' --info | grep -i "adv-addr"
+swift tools/ble-name-scan.swift
 ```
-Ищи строку вида `adv-addr: 88:56:A6:57:B4:F2-Public, ... devicename: Veteran`.
+```
+8F890222-CED7-02BA-4847-42E8C118AE46  rssi=-64  name=NF8687
+```
+
+2. Найти MAC по UUID — `bluetoothd` пишет связку адреса и UUID в открытом виде:
+```bash
+log show --last 30m --predicate 'subsystem == "com.apple.bluetooth"' --info \
+  | grep 8F890222 | grep 'associated with device'
+```
+```
+Address "Public 88:25:83:F6:56:1A" is already associated with device "8F890222-CED7-02BA-4847-42E8C118AE46"
+```
+
+Строка появляется, только если Mac уже пытался подключаться к устройству. Если её нет — подключись к колесу из штатного приложения (или просто дай Mac его «увидеть») и повтори. `sudo` не нужен.
 
 **Android — приложение nRF Connect**
-Scan → найди устройство по имени → MAC под названием устройства.
+Scan → найди устройство по имени → MAC под названием устройства. Android, в отличие от iOS/macOS, показывает настоящий MAC сразу.
 
 **Linux**
 ```bash
@@ -63,6 +82,7 @@ wifi_password: "ПарольОтWiFi"
 ha_encryption_key: "КлючИзHomeAssistant"
 euc_veteran_mac: "XX:XX:XX:XX:XX:XX"   # Veteran Lynx
 euc_nosfet_mac: "XX:XX:XX:XX:XX:XX"    # NOSFET Aero
+euc_xeno_mac: "XX:XX:XX:XX:XX:XX"      # NOSFET Xeno
 fast_charger_mac: "XX:XX:XX:XX:XX:XX" # Fast charger
 ```
 
@@ -83,6 +103,7 @@ esphome-euc-veteran.yaml       — основной конфиг, точка в�
 package-veteran-device.yaml    — пакет одного моноколеса Veteran/NOSFET
 package-charger-device.yaml    — пакет зарядного устройства Fast charger
 my_components/veteran/         — кастомный ESPHome-компонент (C++)
+tools/ble-name-scan.swift      — сканер BLE для macOS (имя → CoreBluetooth-UUID)
 docs/                          — протоколы BLE и описание устройств
 secrets.yaml.example           — шаблон secrets
 ```

--- a/esphome-euc-lynx-nosfet-charger-c6.yaml
+++ b/esphome-euc-lynx-nosfet-charger-c6.yaml
@@ -12,6 +12,8 @@ esphome:
       name: "Veteran Lynx"
     - id: nosfet_device
       name: "Nosfet Aero"
+    - id: xeno_device
+      name: "Nosfet Xeno"
     - id: charger_device
       name: "Fast charger"
   # XIAO ESP32C6: enable RF switch (GPIO3 LOW) and select onboard antenna (GPIO14 LOW)
@@ -48,6 +50,19 @@ packages:
       euc_charge_voltage_offset: 121
       euc_disabled_entities: [low_power_mode, high_speed_mode]
   - !include
+    file: package-veteran-device.yaml
+    vars:
+      euc_id: xeno
+      euc_name: "Nosfet Xeno"
+      euc_mac: !secret euc_xeno_mac
+      euc_device_id: xeno_device
+      euc_nominal_voltage: 126
+      euc_cell_count: 30
+      euc_charge_voltage_min: 122.0
+      euc_charge_stop_offset: 442
+      euc_charge_voltage_offset: 121
+      euc_disabled_entities: [low_power_mode, high_speed_mode]
+  - !include
     file: package-charger-device.yaml
     vars:
       charger_id: fast_charger
@@ -58,6 +73,16 @@ esp32:
   variant: esp32c6
   framework:
     type: esp-idf
+    sdkconfig_options:
+      # ESPHome форсит CONFIG_BT_BLE_42_FEATURES_SUPPORTED=y, а на C6 (SOC_BLE_50_SUPPORTED)
+      # CONFIG_BT_BLE_50_FEATURES_SUPPORTED по умолчанию тоже y. IDF в Kconfig прямо пишет:
+      # "BLE 4.2 and BLE 5.0 cannot be used simultaneously". В таком виде Bluedroid шлёт
+      # LE Extended Create Connection (0x2043), и контроллер отбивает его как Cmd Disallowed,
+      # из-за чего встаёт только одно BLE-соединение. Оставляем 4.2.
+      CONFIG_BT_BLE_50_FEATURES_SUPPORTED: n
+      # ESPHome под max_connections выставляет CONFIG_BTDM_CTRL_BLE_MAX_CONN — опцию
+      # контроллера классического ESP32. У C6 контроллер другой, его лимит задаём сами.
+      CONFIG_BT_LE_MAX_CONNECTIONS: "4"
 logger:
   level: INFO
 wifi:
@@ -90,6 +115,9 @@ web_server:
     - id: sorting_group_nosfet
       name: "Nosfet Aero"
       sorting_weight: 30
+    - id: sorting_group_xeno
+      name: "Nosfet Xeno"
+      sorting_weight: 40
 # XIAO ESP32C6 RF antenna switch:
 #   GPIO3  = RF switch power, must be LOW to enable the switch
 #   GPIO14 = antenna select, LOW = onboard PCB antenna, HIGH = external u.FL
@@ -113,6 +141,9 @@ light:
     output: gpio_d2
     internal: true
     entity_category: "diagnostic"
+# 4 BLE-клиента (Lynx + Aero + Xeno + charger) — дефолтных 3 слотов не хватает
+esp32_ble:
+  max_connections: 4
 esp32_ble_tracker:
 switch:
   - platform: template
@@ -123,14 +154,16 @@ switch:
     web_server:
       sorting_group_id: sorting_group_configuration
       sorting_weight: 0
-    lambda: "return id(connected_lynx).state || id(connected_nosfet).state || id(charger_connected_fast_charger).state;"
+    lambda: "return id(connected_lynx).state || id(connected_nosfet).state || id(connected_xeno).state || id(charger_connected_fast_charger).state;"
     turn_off_action:
       - switch.turn_off: ble_connect_lynx
       - switch.turn_off: ble_connect_nosfet
+      - switch.turn_off: ble_connect_xeno
       - switch.turn_off: ble_connect_fast_charger
     turn_on_action:
       - switch.turn_on: ble_connect_lynx
       - switch.turn_on: ble_connect_nosfet
+      - switch.turn_on: ble_connect_xeno
       - switch.turn_on: ble_connect_fast_charger
 button:
   - platform: restart
@@ -143,7 +176,7 @@ binary_sensor:
   - platform: template
     id: any_ble_connected
     internal: true
-    lambda: "return id(connected_lynx).state || id(connected_nosfet).state || id(charger_connected_fast_charger).state;"
+    lambda: "return id(connected_lynx).state || id(connected_nosfet).state || id(connected_xeno).state || id(charger_connected_fast_charger).state;"
     on_state:
       - if:
           condition:

--- a/esphome-euc-lynx-nosfet-charger.yaml
+++ b/esphome-euc-lynx-nosfet-charger.yaml
@@ -12,6 +12,8 @@ esphome:
       name: "Veteran Lynx"
     - id: nosfet_device
       name: "Nosfet Aero"
+    - id: xeno_device
+      name: "Nosfet Xeno"
     - id: charger_device
       name: "Fast charger"
 packages:
@@ -39,6 +41,19 @@ packages:
       euc_cell_count: 30
       euc_charge_voltage_min: 122.0
       euc_charge_stop_offset: -70
+      euc_charge_voltage_offset: 121
+      euc_disabled_entities: [low_power_mode, high_speed_mode]
+  - !include
+    file: package-veteran-device.yaml
+    vars:
+      euc_id: xeno
+      euc_name: "Nosfet Xeno"
+      euc_mac: !secret euc_xeno_mac
+      euc_device_id: xeno_device
+      euc_nominal_voltage: 126
+      euc_cell_count: 30
+      euc_charge_voltage_min: 122.0
+      euc_charge_stop_offset: 442
       euc_charge_voltage_offset: 121
       euc_disabled_entities: [low_power_mode, high_speed_mode]
   - !include
@@ -86,6 +101,9 @@ web_server:
     - id: sorting_group_nosfet
       name: "Nosfet Aero"
       sorting_weight: 30
+    - id: sorting_group_xeno
+      name: "Nosfet Xeno"
+      sorting_weight: 40
 output:
   - platform: gpio
     pin:
@@ -99,6 +117,9 @@ light:
     output: gpio_d2
     internal: true
     entity_category: "diagnostic"
+# 4 BLE-клиента (Lynx + Aero + Xeno + charger) — дефолтных 3 слотов не хватает
+esp32_ble:
+  max_connections: 4
 esp32_ble_tracker:
 switch:
   - platform: template
@@ -109,14 +130,16 @@ switch:
     web_server:
       sorting_group_id: sorting_group_configuration
       sorting_weight: 0
-    lambda: "return id(connected_lynx).state || id(connected_nosfet).state || id(charger_connected_fast_charger).state;"
+    lambda: "return id(connected_lynx).state || id(connected_nosfet).state || id(connected_xeno).state || id(charger_connected_fast_charger).state;"
     turn_off_action:
       - switch.turn_off: ble_connect_lynx
       - switch.turn_off: ble_connect_nosfet
+      - switch.turn_off: ble_connect_xeno
       - switch.turn_off: ble_connect_fast_charger
     turn_on_action:
       - switch.turn_on: ble_connect_lynx
       - switch.turn_on: ble_connect_nosfet
+      - switch.turn_on: ble_connect_xeno
       - switch.turn_on: ble_connect_fast_charger
 button:
   - platform: restart
@@ -129,7 +152,7 @@ binary_sensor:
   - platform: template
     id: any_ble_connected
     internal: true
-    lambda: "return id(connected_lynx).state || id(connected_nosfet).state || id(charger_connected_fast_charger).state;"
+    lambda: "return id(connected_lynx).state || id(connected_nosfet).state || id(connected_xeno).state || id(charger_connected_fast_charger).state;"
     on_state:
       - if:
           condition:

--- a/secrets.yaml.example
+++ b/secrets.yaml.example
@@ -9,4 +9,5 @@ ha_encryption_key: ""
 euc_inmotion_mac: "XX:XX:XX:XX:XX:XX"
 euc_veteran_mac: "XX:XX:XX:XX:XX:XX"
 euc_nosfet_mac: "XX:XX:XX:XX:XX:XX"
+euc_xeno_mac: "XX:XX:XX:XX:XX:XX"
 fast_charger_mac: "XX:XX:XX:XX:XX:XX"  # Fast charger

--- a/tools/ble-name-scan.swift
+++ b/tools/ble-name-scan.swift
@@ -1,0 +1,37 @@
+// Сканер BLE для macOS: выводит имя устройства и его CoreBluetooth-UUID.
+// CoreBluetooth не отдаёт MAC — только UUID, локальный для этого Mac.
+// Чтобы получить MAC, найди здесь UUID нужного имени, затем:
+//   log show --last 30m --predicate 'subsystem == "com.apple.bluetooth"' --info \
+//     | grep '<UUID>' | grep 'associated with device'
+// Запуск: swift tools/ble-name-scan.swift
+import Foundation
+import CoreBluetooth
+
+final class Scanner: NSObject, CBCentralManagerDelegate {
+    var central: CBCentralManager!
+    var seen = Set<String>()
+
+    override init() {
+        super.init()
+        central = CBCentralManager(delegate: self, queue: nil)
+    }
+
+    func centralManagerDidUpdateState(_ c: CBCentralManager) {
+        print("state=\(c.state.rawValue) (5=poweredOn, 3=unauthorized)")
+        if c.state == .poweredOn {
+            c.scanForPeripherals(withServices: nil, options: nil)
+        }
+    }
+
+    func centralManager(_ c: CBCentralManager, didDiscover p: CBPeripheral,
+                        advertisementData: [String: Any], rssi RSSI: NSNumber) {
+        let name = p.name ?? (advertisementData[CBAdvertisementDataLocalNameKey] as? String) ?? "-"
+        if seen.insert(p.identifier.uuidString).inserted {
+            print("\(p.identifier.uuidString)  rssi=\(RSSI)  name=\(name)")
+        }
+    }
+}
+
+let scanner = Scanner()
+RunLoop.main.run(until: Date(timeIntervalSinceNow: 25))
+print("--- done, \(scanner.seen.count) devices")


### PR DESCRIPTION
## Что сделано

Добавлено третье моноколесо **Nosfet Xeno** (30S/126 В) в оба мульти-конфига: запись в `esphome: devices:`, пакет `package-veteran-device.yaml`, sorting-группа и лямбды `Bluetooth` / `any_ble_connected`.

Параметры совпадают с Aero, кроме `euc_charge_stop_offset` — он у каждой прошивки свой и выводится эмпирически (для Xeno получилось **442**).

## Найденные дефекты

Четвёртый BLE-клиент вскрыл две независимые проблемы на плате C6: поднималось ровно **одно** соединение, все остальные падали с `status=133`.

**1. Одновременно включённые BLE 4.2 и 5.0.** ESPHome форсит `CONFIG_BT_BLE_42_FEATURES_SUPPORTED=y`, а на C6 (`SOC_BLE_50_SUPPORTED`) флаг `CONFIG_BT_BLE_50_FEATURES_SUPPORTED` по умолчанию тоже `y`. Kconfig ESP-IDF про это пишет прямым текстом: *«BLE 4.2 and BLE 5.0 cannot be used simultaneously»*. В таком виде Bluedroid шлёт расширенную команду LE Extended Create Connection (HCI `0x2043`), а контроллер отбивает её как `Cmd Disallowed`. Фиксируем сборку на 4.2.

**2. `max_connections` не доезжает до контроллера C6.** ESPHome транслирует его в `CONFIG_BTDM_CTRL_BLE_MAX_CONN` — опцию контроллера *классического* ESP32. У C6 контроллер другой, его лимит `CONFIG_BT_LE_MAX_CONNECTIONS` оставался равен 3. Задаём явно.

К конфигу на `esp32dev` ничего из этого не относится: у классического ESP32 нет BLE 5.0 вовсе, а опция контроллера — ровно та, которую ESPHome и так выставляет.

## Проверка на железе

Прошито по OTA на XIAO ESP32C6. Lynx + Xeno + зарядка держат соединение одновременно, в логе ноль ошибок и ноль `Cmd Disallowed`. Телеметрия Xeno декодируется корректно: 113.54 В при 65.4 % заряда (сходится для 30S), пробег 105 км, прошивка 45.2.50.

**Не проверено:** `euc_charge_stop_offset: 442` — колесо ушло в автовыключение до сверки, ожидается показание `126.0`. Также не проверен `euc_charge_voltage_offset: 121` (скопирован от Aero), поскольку проверка означает запись реального лимита заряда в колесо.

## Заодно

Документирован способ добыть BLE-MAC на macOS. CoreBluetooth его намеренно скрывает, а в унифицированном логе адреса редактируются как `<private>` — прежний рецепт `log stream | grep adv-addr` на macOS 26 не даёт ничего. Рабочий путь в два шага: `tools/ble-name-scan.swift` сопоставляет имя устройства с CoreBluetooth-UUID, а `bluetoothd` логирует этот UUID рядом с публичным адресом.

🤖 Generated with [Claude Code](https://claude.com/claude-code)